### PR TITLE
gemspecの開発時の依存関係にrspecが足りない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*~
+.rvmrc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/lib/okura_cmd.rb
+++ b/lib/okura_cmd.rb
@@ -1,5 +1,7 @@
-# TODO: requireにすると読めない
-load File.join(File.dirname(__FILE__),'okura.rb')
+# -*- coding: utf-8 -*-
+$LOAD_PATH.unshift '.'
+require 'okura'
+
 dict_dir=$*[0]
 
 puts 'loading words'

--- a/okura.gemspec
+++ b/okura.gemspec
@@ -6,6 +6,8 @@ Gem::Specification.new do |s|
   s.email       = 'discommunicative@gmail.com'
   s.homepage    = 'https://github.com/todesking/okura'
 
+  s.add_development_dependency 'rspec', ['~> 2.3.0']
+
   s.version     = '0.0.0.snapshot'
   s.files       = Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
 end


### PR DESCRIPTION
ので足しました。

あと、okura_cmd.rbでokuraがrequireできない問題は、
ruby 1.9だと$LOAD_PATHにカレントディレクトリが含まれないためです。
