### PR TITLE
Mute debugging output

### DIFF
--- a/lib/okura/word_dic.rb
+++ b/lib/okura/word_dic.rb
@@ -237,7 +237,6 @@ module Okura
         # [ Words, [Integer], [Integer] ] -> WordDic::DoubleArray
         def self.build_from_serialized data
           words,base,check=data
-          puts base.length
           DoubleArray.new words,base,check
         end
       end


### PR DESCRIPTION
Even `% bundle exec ruby config/environment.rb` shows some number when this gem is bundled.
